### PR TITLE
Modified IsPrefManaged to always use system python

### DIFF
--- a/SignInHelper
+++ b/SignInHelper
@@ -50,7 +50,7 @@ function GetLoggedInUser {
 function IsPrefManaged {
 	local PREFKEY="$1"
 	local PREFDOMAIN="$2"
-	local MANAGED=$(python -c "from Foundation import CFPreferencesAppValueIsForced; print CFPreferencesAppValueIsForced('${PREFKEY}', '${PREFDOMAIN}')")
+	local MANAGED=$(/usr/bin/python -c "from Foundation import CFPreferencesAppValueIsForced; print CFPreferencesAppValueIsForced('${PREFKEY}', '${PREFDOMAIN}')")
 	if [ "$MANAGED" == "True" ]; then
 		echo "1"
 	else


### PR DESCRIPTION
IsPrefManaged would use python from $PATH, which may not always be system python and therefore cannot be guaranteed to have the `Foundation` library available.