### PR TITLE
Resolve issue that writes MeContact.plist to wrong path when $3 is undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# SignInHelper
-<b>Microsoft Office for Mac Sign In Helper</b><br/>
+# Microsoft Office for Mac Sign In Helper
 
-Purpose: Detects UPN of logged-on user and pre-fills Office and Skype for Business Sign In page<br/>
+Purpose: Detects UPN of logged-on user and pre-fills Office and Skype for Business Sign In page.
 
-
-This script is Jamf Pro compatible and can be pasted directly, without modification, into a new script window in the Jamf admin console.<br/>
+This script is Jamf Pro compatible and can be pasted directly, without modification, into a new script window in the Jamf admin console.
 When running under Jamf Pro, no additional parameters need to be specified.
 
 See https://www.office4mac.com/courses/mgmt300 for the training video on how to use this helper!

--- a/SignInHelper
+++ b/SignInHelper
@@ -2,7 +2,7 @@
 #set -x
 
 TOOL_NAME="Microsoft Office for Mac Sign In Helper"
-TOOL_VERSION="1.2.1"
+TOOL_VERSION="1.3.0"
 
 ## Copyright (c) 2018 Microsoft Corp. All rights reserved.
 ## Scripts are not supported under any Microsoft standard support program or service. The scripts are provided AS IS without warranty of any kind.

--- a/SignInHelper
+++ b/SignInHelper
@@ -170,8 +170,7 @@ SetPrefillOffice() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'OfficeActivationEmailAddress'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeActivationEmailAddress -string "${UPN}"
-		if [ "$?" = "0" ]; then
+		if ${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeActivationEmailAddress -string "${UPN}"; then
 			echo ">>SUCCESS - Set 'OfficeActivationEmailAddress' to ${UPN}"
 		else
 			echo ">>ERROR - Did not set value for 'OfficeActivationEmailAddress'"
@@ -186,8 +185,7 @@ SetAutoSignIn() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>WARNING - Cannot override managed preference 'OfficeAutoSignIn'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeAutoSignIn -bool TRUE
-		if [ "$?" = "0" ]; then
+		if ${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeAutoSignIn -bool true; then
 			echo ">>SUCCESS - Set 'OfficeAutoSignIn' to TRUE"
 		else
 			echo ">>ERROR - Did not set value for 'OfficeAutoSignIn'"
@@ -203,8 +201,7 @@ SetOfficeUser() {
 	if [ "$USERNAME" = "" ]; then
 		echo ">>WARNING - Cannot set Office user name"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write "${HOME}/Library/Group Containers/UBF8T346G9.Office/MeContact.plist" Name -string "${USERNAME}"
-		if [ "$?" = "0" ]; then
+		if ${CMD_PREFIX} /usr/bin/defaults write "${HOME}/Library/Group Containers/UBF8T346G9.Office/MeContact.plist" Name -string "${USERNAME}"; then
 			echo ">>SUCCESS - Set Office user name to '${USERNAME}'"
 		else
 			echo ">>WARNING - Did not set Office user name'"
@@ -213,8 +210,7 @@ SetOfficeUser() {
 	if [ "$INITIALS" = "" ]; then
 		echo ">>WARNING - Cannot set Office user initials"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write "${HOME}/Library/Group Containers/UBF8T346G9.Office/MeContact.plist" Initials -string "${INITIALS}"
-		if [ "$?" = "0" ]; then
+		if ${CMD_PREFIX} /usr/bin/defaults write "${HOME}/Library/Group Containers/UBF8T346G9.Office/MeContact.plist" Initials -string "${INITIALS}"; then
 			echo ">>SUCCESS - Set Office user initials to '${INITIALS}'"
 		else
 			echo ">>WARNING - Did not set Office user initials'"
@@ -229,8 +225,7 @@ SetPrefillSkypeForBusiness() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'userName'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness userName -string "${UPN}"
-		if [ "$?" = "0" ]; then
+		if ${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness userName -string "${UPN}"; then
 			echo ">>SUCCESS - Set 'userName' to ${UPN}"
 		else
 			echo ">>ERROR - Did not set value for 'userName'"
@@ -242,8 +237,7 @@ SetPrefillSkypeForBusiness() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'sipAddress'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness sipAddress -string "${SIP}"
-		if [ "$?" = "0" ]; then
+		if ${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness sipAddress -string "${SIP}"; then
 			echo ">>SUCCESS - Set 'sipAddress' to ${SIP}"
 		else
 			echo ">>ERROR - Did not set value for 'sipAddress'"

--- a/SignInHelper
+++ b/SignInHelper
@@ -19,7 +19,7 @@ TOOL_VERSION="1.3.0"
 
 # Shows tool usage and parameters
 ShowUsage() {
-	echo $TOOL_NAME - $TOOL_VERSION
+	echo "$TOOL_NAME - $TOOL_VERSION"
 	echo "Purpose: Detects UPN of logged-on user and pre-fills Office and Skype for Business Sign In page"
 	echo "Usage: $0 [--Verbose]"
 	echo
@@ -118,7 +118,7 @@ GetUPN() {
 	DOMAIN="$1"
 	NAMESPACE="$2"
 	ACCOUNT="$3"
-	UPN=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT userPrincipalName | grep -o 'userPrincipalName:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
+	UPN=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName="$ACCOUNT" userPrincipalName | grep -o 'userPrincipalName:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
 	if [ "$UPN" = "" ]; then
 		echo "0"
 	else
@@ -131,7 +131,7 @@ GetDisplayName() {
 	DOMAIN="$1"
 	NAMESPACE="$2"
 	ACCOUNT="$3"
-	DISPLAYNAME=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT displayName | grep -o 'displayName:.*' | cut -d : -f2 | cut -c 2- 2> /dev/null)
+	DISPLAYNAME=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName="$ACCOUNT" displayName | grep -o 'displayName:.*' | cut -d : -f2 | cut -c 2- 2> /dev/null)
 	if [ "$DISPLAYNAME" = "" ]; then
 		echo "0"
 	else
@@ -142,10 +142,10 @@ GetDisplayName() {
 # Parse initials from the displayName
 GetInitials() {
 	DISPLAYNAME="$1"
-	FIRST=$(echo ${DISPLAYNAME} | cut -d ' ' -f1 | cut -c 1)
-	SECOND=$(echo ${DISPLAYNAME} | cut -d ' ' -f2 | cut -c 1)
-	THIRD=$(echo ${DISPLAYNAME} | cut -d ' ' -f3 | cut -c 1)
-	INITIALS=$(echo ${FIRST}${SECOND}${THIRD})
+	FIRST=$(echo "${DISPLAYNAME}" | cut -d ' ' -f1 | cut -c 1)
+	SECOND=$(echo "${DISPLAYNAME}" | cut -d ' ' -f2 | cut -c 1)
+	THIRD=$(echo "${DISPLAYNAME}" | cut -d ' ' -f3 | cut -c 1)
+	INITIALS="${FIRST}${SECOND}${THIRD}"
 	if [ "$INITIALS" = "" ]; then
 		echo "0"
 	else
@@ -169,7 +169,7 @@ SetPrefillOffice() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'OfficeActivationEmailAddress'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeActivationEmailAddress -string ${UPN}
+		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeActivationEmailAddress -string "${UPN}"
 		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'OfficeActivationEmailAddress' to ${UPN}"
 		else
@@ -202,7 +202,7 @@ SetOfficeUser() {
 	if [ "$USERNAME" = "" ]; then
 		echo ">>WARNING - Cannot set Office user name"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write ${HOME}/Library/Group\ Containers/UBF8T346G9.Office/MeContact.plist Name -string "${USERNAME}"
+		${CMD_PREFIX} /usr/bin/defaults write "${HOME}/Library/Group Containers/UBF8T346G9.Office/MeContact.plist" Name -string "${USERNAME}"
 		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set Office user name to '${USERNAME}'"
 		else
@@ -212,7 +212,7 @@ SetOfficeUser() {
 	if [ "$INITIALS" = "" ]; then
 		echo ">>WARNING - Cannot set Office user initials"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write ${HOME}/Library/Group\ Containers/UBF8T346G9.Office/MeContact.plist Initials -string "${INITIALS}"
+		${CMD_PREFIX} /usr/bin/defaults write "${HOME}/Library/Group Containers/UBF8T346G9.Office/MeContact.plist" Initials -string "${INITIALS}"
 		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set Office user initials to '${INITIALS}'"
 		else
@@ -228,7 +228,7 @@ SetPrefillSkypeForBusiness() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'userName'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness userName -string ${UPN}
+		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness userName -string "${UPN}"
 		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'userName' to ${UPN}"
 		else
@@ -241,7 +241,7 @@ SetPrefillSkypeForBusiness() {
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'sipAddress'"
 	else
-		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness sipAddress -string ${SIP}
+		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness sipAddress -string "${SIP}"
 		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'sipAddress' to ${SIP}"
 		else

--- a/SignInHelper
+++ b/SignInHelper
@@ -18,7 +18,7 @@ TOOL_VERSION="1.3.0"
 ## When running under Jamf Pro, no additional parameters need to be specified.
 
 # Shows tool usage and parameters
-function ShowUsage {
+ShowUsage() {
 	echo $TOOL_NAME - $TOOL_VERSION
 	echo "Purpose: Detects UPN of logged-on user and pre-fills Office and Skype for Business Sign In page"
 	echo "Usage: $0 [--Verbose]"
@@ -27,7 +27,7 @@ function ShowUsage {
 }
 
 # Checks to see if the script is running as root
-function RunningAsRoot {
+RunningAsRoot() {
 	if [ "$EUID" = "0" ]; then
 		echo "1"
 	else
@@ -36,7 +36,7 @@ function RunningAsRoot {
 }
 
 # Returns the name of the logged-in user, which is useful if the script is running in the root context
-function GetLoggedInUser {
+GetLoggedInUser() {
 	# The following line is courtesy of @scriptingosx - https://scriptingosx.com/2019/09/get-current-user-in-shell-scripts-on-macos/
 	local LOGGEDIN=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 	if [ "$LOGGEDIN" == "" ]; then
@@ -47,7 +47,7 @@ function GetLoggedInUser {
 }
 
 # HOME folder detection
-function GetHomeFolder {
+GetHomeFolder() {
 	HOME=$(dscl . read /Users/"$1" NFSHomeDirectory | cut -d ':' -f2 | cut -d ' ' -f2)
 	if [ "$HOME" == "" ]; then
 		if [ -d "/Users/$1" ]; then
@@ -59,7 +59,7 @@ function GetHomeFolder {
 }
 
 # Detects whether a given preference is managed
-function IsPrefManaged {
+IsPrefManaged() {
 	local PREFKEY="$1"
 	local PREFDOMAIN="$2"
 	local MANAGED=$(/usr/bin/python -c "from Foundation import CFPreferencesAppValueIsForced; print CFPreferencesAppValueIsForced('${PREFKEY}', '${PREFDOMAIN}')")
@@ -71,7 +71,7 @@ function IsPrefManaged {
 }
 
 # Detect Kerberos cache
-function DetectKerbCache {
+DetectKerbCache() {
 	local KERB=$(${CMD_PREFIX} /usr/bin/klist 2> /dev/null)
 	if [ "$KERB" == "" ]; then
 		echo "0"
@@ -81,7 +81,7 @@ function DetectKerbCache {
 }
 
 # Get the Kerberos principal from the cache
-function GetPrincipal {
+GetPrincipal() {
 	local PRINCIPAL=$(${CMD_PREFIX} /usr/bin/klist | grep -o 'Principal: .*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
 	if [ "$PRINCIPAL" == "" ]; then
 		echo "0"
@@ -91,19 +91,19 @@ function GetPrincipal {
 }
 
 # Extract account name from principal
-function GetAccountName {
+GetAccountName() {
 	local PRINCIPAL="$1"
 	echo "$PRINCIPAL" | cut -d @ -f1
 }
 
 # Extract domain name from principal
-function GetDomainName {
+GetDomainName() {
 	local PRINCIPAL="$1"
 	echo "$PRINCIPAL" | cut -d @ -f2
 }
 
 # Get the defaultNamingContext from LDAP
-function GetDefaultNamingContext {
+GetDefaultNamingContext() {
 	local DOMAIN="$1"
 	local DOMAINNC=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b '' -s base defaultNamingContext | grep -o 'defaultNamingContext:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
 	if [ "$DOMAINNC" == "" ]; then
@@ -114,7 +114,7 @@ function GetDefaultNamingContext {
 }
 
 # Get the UPN for the user account
-function GetUPN {
+GetUPN() {
 	local DOMAIN="$1"
 	local NAMESPACE="$2"
 	local ACCOUNT="$3"
@@ -127,7 +127,7 @@ function GetUPN {
 }
 
 # Get the displayName for the user account
-function GetDisplayName {
+GetDisplayName() {
 	local DOMAIN="$1"
 	local NAMESPACE="$2"
 	local ACCOUNT="$3"
@@ -140,7 +140,7 @@ function GetDisplayName {
 }
 
 # Parse initials from the displayName
-function GetInitials {
+GetInitials() {
 	local DISPLAYNAME="$1"
 	local FIRST=$(echo ${DISPLAYNAME} | cut -d ' ' -f1 | cut -c 1)
 	local SECOND=$(echo ${DISPLAYNAME} | cut -d ' ' -f2 | cut -c 1)
@@ -154,7 +154,7 @@ function GetInitials {
 }
 
 # Set Sign In keys
-function SetPrefill {
+SetPrefill() {
 	local UPN="$1"
 	SetPrefillOffice "$UPN"
 	SetPrefillSkypeForBusiness "$UPN"
@@ -163,7 +163,7 @@ function SetPrefill {
 }
 
 # Set Home Realm Discovery for Office apps
-function SetPrefillOffice {
+SetPrefillOffice() {
 	local UPN="$1"
 	local KEYMANAGED=$(IsPrefManaged "OfficeActivationEmailAddress" "com.microsoft.office")
 	if [ "$KEYMANAGED" == "1" ]; then
@@ -180,7 +180,7 @@ function SetPrefillOffice {
 }
 
 # Set Office Automatic Office Sign In
-function SetAutoSignIn {
+SetAutoSignIn() {
 	local KEYMANAGED=$(IsPrefManaged "OfficeAutoSignIn" "com.microsoft.office")
 	if [ "$KEYMANAGED" == "1" ]; then
 		echo ">>WARNING - Cannot override managed preference 'OfficeAutoSignIn'"
@@ -196,7 +196,7 @@ function SetAutoSignIn {
 }
 
 # Set Office Username and Initials
-function SetOfficeUser {
+SetOfficeUser() {
 	local USERNAME="$1"
 	local INITIALS="$2"
 	if [ "$USERNAME" == "" ]; then
@@ -222,7 +222,7 @@ function SetOfficeUser {
 }
 
 # Set Skype for Business Sign In
-function SetPrefillSkypeForBusiness {
+SetPrefillSkypeForBusiness() {
 	local UPN="$1"
 	local KEYMANAGED=$(IsPrefManaged "userName" "com.microsoft.SkypeForBusiness")
 	if [ "$KEYMANAGED" == "1" ]; then
@@ -252,7 +252,7 @@ function SetPrefillSkypeForBusiness {
 }
 
 # Detect Domain Join
-function DetectDomainJoin {
+DetectDomainJoin() {
 	local DSCONFIGAD=$(${CMD_PREFIX} /usr/sbin/dsconfigad -show)
 	if [ "$DSCONFIGAD" == "" ]; then
 		echo "0"
@@ -262,7 +262,7 @@ function DetectDomainJoin {
 }
 
 # Detect Jamf presence
-function DetectJamf {
+DetectJamf() {
 	if [ -e "/Library/Preferences/com.jamfsoftware.jamf.plist" ]; then
 		echo "1"
 	else
@@ -271,7 +271,7 @@ function DetectJamf {
 }
 
 # Detect NoMAD presence
-function DetectNoMAD {
+DetectNoMAD() {
 	local NOMAD=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD 2> /dev/null)
 	if [ "$NOMAD" == "" ]; then
 		echo "0"
@@ -281,7 +281,7 @@ function DetectNoMAD {
 }
 
 # Get the UPN from NoMAD's preference cache
-function GetUPNfromNoMAD {
+GetUPNfromNoMAD() {
 	local NMUPN=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD UserUPN 2> /dev/null)
 	if [ "$NMUPN" == "" ]; then
 		echo "0"
@@ -291,7 +291,7 @@ function GetUPNfromNoMAD {
 }
 
 # Get the DisplayName from NoMAD's preference cache
-function GetDisplayNamefromNoMAD {
+GetDisplayNamefromNoMAD() {
 	local NMDISPLAYNAME=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD DisplayName 2> /dev/null)
 	if [ "$NMDISPLAYNAME" == "" ]; then
 		echo "0"
@@ -301,7 +301,7 @@ function GetDisplayNamefromNoMAD {
 }
 
 # Detect Enterprise Connect presence
-function DetectEnterpriseConnect {
+DetectEnterpriseConnect() {
 	local EC=$(${CMD_PREFIX} /usr/bin/defaults read com.apple.Enterprise-Connect 2> /dev/null)
 	if [ "$EC" == "" ]; then
 		echo "0"
@@ -311,7 +311,7 @@ function DetectEnterpriseConnect {
 }
 
 # Get the UPN from Enterprise Connect (code courtesy of Dennis Browning)
-function GetUPNfromEnterpriseConnect {
+GetUPNfromEnterpriseConnect() {
 	local ECUPN=$(${CMD_PREFIX} "/Applications/Enterprise Connect.app/Contents/SharedSupport/eccl" -a userPrincipalName | awk '/userPrincipalName:/{print $NF}' 2> /dev/null)
 	if [ "$ECUPN" == "" ]; then
 		echo "0"

--- a/SignInHelper
+++ b/SignInHelper
@@ -28,7 +28,7 @@ ShowUsage() {
 
 # Checks to see if the script is running as root
 RunningAsRoot() {
-    # shellcheck disable=SC2039
+	# shellcheck disable=SC2039
 	if [ "$EUID" = "0" ]; then
 		echo "1"
 	else
@@ -319,15 +319,15 @@ GetUPNfromEnterpriseConnect() {
 while [ $# -gt 0 ]; do
 	key="$1"
 	case "$key" in
-    	--Help|-h|--help)
-    	ShowUsage
-    	exit 0
+		--Help|-h|--help)
+		ShowUsage
+		exit 0
 		shift # past argument
-    	;;
-    	--Verbose|-v|--verbose)
-    	set -x
-    	shift # past argument
-    	;;
+		;;
+		--Verbose|-v|--verbose)
+		set -x
+		shift # past argument
+		;;
 	esac
 	shift # past argument or value
 done

--- a/SignInHelper
+++ b/SignInHelper
@@ -28,6 +28,7 @@ ShowUsage() {
 
 # Checks to see if the script is running as root
 RunningAsRoot() {
+    # shellcheck disable=SC2039
 	if [ "$EUID" = "0" ]; then
 		echo "1"
 	else

--- a/SignInHelper
+++ b/SignInHelper
@@ -322,8 +322,7 @@ GetUPNfromEnterpriseConnect() {
 }
 
 # Evaluate command-line arguments
-while [[ $# > 0 ]]
-do
+while [ $# -gt 0 ]; do
 	key="$1"
 	case "$key" in
     	--Help|-h|--help)

--- a/SignInHelper
+++ b/SignInHelper
@@ -38,7 +38,7 @@ RunningAsRoot() {
 # Returns the name of the logged-in user, which is useful if the script is running in the root context
 GetLoggedInUser() {
 	# The following line is courtesy of @scriptingosx - https://scriptingosx.com/2019/09/get-current-user-in-shell-scripts-on-macos/
-	local LOGGEDIN=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
+	LOGGEDIN=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 	if [ "$LOGGEDIN" = "" ]; then
 		echo "0"
 	else
@@ -60,9 +60,9 @@ GetHomeFolder() {
 
 # Detects whether a given preference is managed
 IsPrefManaged() {
-	local PREFKEY="$1"
-	local PREFDOMAIN="$2"
-	local MANAGED=$(/usr/bin/python -c "from Foundation import CFPreferencesAppValueIsForced; print CFPreferencesAppValueIsForced('${PREFKEY}', '${PREFDOMAIN}')")
+	PREFKEY="$1"
+	PREFDOMAIN="$2"
+	MANAGED=$(/usr/bin/python -c "from Foundation import CFPreferencesAppValueIsForced; print CFPreferencesAppValueIsForced('${PREFKEY}', '${PREFDOMAIN}')")
 	if [ "$MANAGED" = "True" ]; then
 		echo "1"
 	else
@@ -72,7 +72,7 @@ IsPrefManaged() {
 
 # Detect Kerberos cache
 DetectKerbCache() {
-	local KERB=$(${CMD_PREFIX} /usr/bin/klist 2> /dev/null)
+	KERB=$(${CMD_PREFIX} /usr/bin/klist 2> /dev/null)
 	if [ "$KERB" = "" ]; then
 		echo "0"
 	else
@@ -82,7 +82,7 @@ DetectKerbCache() {
 
 # Get the Kerberos principal from the cache
 GetPrincipal() {
-	local PRINCIPAL=$(${CMD_PREFIX} /usr/bin/klist | grep -o 'Principal: .*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
+	PRINCIPAL=$(${CMD_PREFIX} /usr/bin/klist | grep -o 'Principal: .*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
 	if [ "$PRINCIPAL" = "" ]; then
 		echo "0"
 	else
@@ -92,20 +92,20 @@ GetPrincipal() {
 
 # Extract account name from principal
 GetAccountName() {
-	local PRINCIPAL="$1"
+	PRINCIPAL="$1"
 	echo "$PRINCIPAL" | cut -d @ -f1
 }
 
 # Extract domain name from principal
 GetDomainName() {
-	local PRINCIPAL="$1"
+	PRINCIPAL="$1"
 	echo "$PRINCIPAL" | cut -d @ -f2
 }
 
 # Get the defaultNamingContext from LDAP
 GetDefaultNamingContext() {
-	local DOMAIN="$1"
-	local DOMAINNC=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b '' -s base defaultNamingContext | grep -o 'defaultNamingContext:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
+	DOMAIN="$1"
+	DOMAINNC=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b '' -s base defaultNamingContext | grep -o 'defaultNamingContext:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
 	if [ "$DOMAINNC" = "" ]; then
 		echo "0"
 	else
@@ -115,10 +115,10 @@ GetDefaultNamingContext() {
 
 # Get the UPN for the user account
 GetUPN() {
-	local DOMAIN="$1"
-	local NAMESPACE="$2"
-	local ACCOUNT="$3"
-	local UPN=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT userPrincipalName | grep -o 'userPrincipalName:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
+	DOMAIN="$1"
+	NAMESPACE="$2"
+	ACCOUNT="$3"
+	UPN=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT userPrincipalName | grep -o 'userPrincipalName:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
 	if [ "$UPN" = "" ]; then
 		echo "0"
 	else
@@ -128,10 +128,10 @@ GetUPN() {
 
 # Get the displayName for the user account
 GetDisplayName() {
-	local DOMAIN="$1"
-	local NAMESPACE="$2"
-	local ACCOUNT="$3"
-	local DISPLAYNAME=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT displayName | grep -o 'displayName:.*' | cut -d : -f2 | cut -c 2- 2> /dev/null)
+	DOMAIN="$1"
+	NAMESPACE="$2"
+	ACCOUNT="$3"
+	DISPLAYNAME=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT displayName | grep -o 'displayName:.*' | cut -d : -f2 | cut -c 2- 2> /dev/null)
 	if [ "$DISPLAYNAME" = "" ]; then
 		echo "0"
 	else
@@ -141,11 +141,11 @@ GetDisplayName() {
 
 # Parse initials from the displayName
 GetInitials() {
-	local DISPLAYNAME="$1"
-	local FIRST=$(echo ${DISPLAYNAME} | cut -d ' ' -f1 | cut -c 1)
-	local SECOND=$(echo ${DISPLAYNAME} | cut -d ' ' -f2 | cut -c 1)
-	local THIRD=$(echo ${DISPLAYNAME} | cut -d ' ' -f3 | cut -c 1)
-	local INITIALS=$(echo ${FIRST}${SECOND}${THIRD})
+	DISPLAYNAME="$1"
+	FIRST=$(echo ${DISPLAYNAME} | cut -d ' ' -f1 | cut -c 1)
+	SECOND=$(echo ${DISPLAYNAME} | cut -d ' ' -f2 | cut -c 1)
+	THIRD=$(echo ${DISPLAYNAME} | cut -d ' ' -f3 | cut -c 1)
+	INITIALS=$(echo ${FIRST}${SECOND}${THIRD})
 	if [ "$INITIALS" = "" ]; then
 		echo "0"
 	else
@@ -155,7 +155,7 @@ GetInitials() {
 
 # Set Sign In keys
 SetPrefill() {
-	local UPN="$1"
+	UPN="$1"
 	SetPrefillOffice "$UPN"
 	SetPrefillSkypeForBusiness "$UPN"
 	### Comment out the next line if you don't want to enable automatic sign in, or you are setting it separately in a Configuration Profile
@@ -164,8 +164,8 @@ SetPrefill() {
 
 # Set Home Realm Discovery for Office apps
 SetPrefillOffice() {
-	local UPN="$1"
-	local KEYMANAGED=$(IsPrefManaged "OfficeActivationEmailAddress" "com.microsoft.office")
+	UPN="$1"
+	KEYMANAGED=$(IsPrefManaged "OfficeActivationEmailAddress" "com.microsoft.office")
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'OfficeActivationEmailAddress'"
 	else
@@ -181,7 +181,7 @@ SetPrefillOffice() {
 
 # Set Office Automatic Office Sign In
 SetAutoSignIn() {
-	local KEYMANAGED=$(IsPrefManaged "OfficeAutoSignIn" "com.microsoft.office")
+	KEYMANAGED=$(IsPrefManaged "OfficeAutoSignIn" "com.microsoft.office")
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>WARNING - Cannot override managed preference 'OfficeAutoSignIn'"
 	else
@@ -197,8 +197,8 @@ SetAutoSignIn() {
 
 # Set Office Username and Initials
 SetOfficeUser() {
-	local USERNAME="$1"
-	local INITIALS="$2"
+	USERNAME="$1"
+	INITIALS="$2"
 	if [ "$USERNAME" = "" ]; then
 		echo ">>WARNING - Cannot set Office user name"
 	else
@@ -223,8 +223,8 @@ SetOfficeUser() {
 
 # Set Skype for Business Sign In
 SetPrefillSkypeForBusiness() {
-	local UPN="$1"
-	local KEYMANAGED=$(IsPrefManaged "userName" "com.microsoft.SkypeForBusiness")
+	UPN="$1"
+	KEYMANAGED=$(IsPrefManaged "userName" "com.microsoft.SkypeForBusiness")
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'userName'"
 	else
@@ -236,8 +236,8 @@ SetPrefillSkypeForBusiness() {
 			exit 1
 		fi
 	fi
-	local SIP="$1"
-	local KEYMANAGED=$(IsPrefManaged "sipAddress" "com.microsoft.SkypeForBusiness")
+	SIP="$1"
+	KEYMANAGED=$(IsPrefManaged "sipAddress" "com.microsoft.SkypeForBusiness")
 	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'sipAddress'"
 	else
@@ -253,7 +253,7 @@ SetPrefillSkypeForBusiness() {
 
 # Detect Domain Join
 DetectDomainJoin() {
-	local DSCONFIGAD=$(${CMD_PREFIX} /usr/sbin/dsconfigad -show)
+	DSCONFIGAD=$(${CMD_PREFIX} /usr/sbin/dsconfigad -show)
 	if [ "$DSCONFIGAD" = "" ]; then
 		echo "0"
 	else
@@ -272,7 +272,7 @@ DetectJamf() {
 
 # Detect NoMAD presence
 DetectNoMAD() {
-	local NOMAD=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD 2> /dev/null)
+	NOMAD=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD 2> /dev/null)
 	if [ "$NOMAD" = "" ]; then
 		echo "0"
 	else
@@ -282,7 +282,7 @@ DetectNoMAD() {
 
 # Get the UPN from NoMAD's preference cache
 GetUPNfromNoMAD() {
-	local NMUPN=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD UserUPN 2> /dev/null)
+	NMUPN=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD UserUPN 2> /dev/null)
 	if [ "$NMUPN" = "" ]; then
 		echo "0"
 	else
@@ -292,7 +292,7 @@ GetUPNfromNoMAD() {
 
 # Get the DisplayName from NoMAD's preference cache
 GetDisplayNamefromNoMAD() {
-	local NMDISPLAYNAME=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD DisplayName 2> /dev/null)
+	NMDISPLAYNAME=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD DisplayName 2> /dev/null)
 	if [ "$NMDISPLAYNAME" = "" ]; then
 		echo "0"
 	else
@@ -302,7 +302,7 @@ GetDisplayNamefromNoMAD() {
 
 # Detect Enterprise Connect presence
 DetectEnterpriseConnect() {
-	local EC=$(${CMD_PREFIX} /usr/bin/defaults read com.apple.Enterprise-Connect 2> /dev/null)
+	EC=$(${CMD_PREFIX} /usr/bin/defaults read com.apple.Enterprise-Connect 2> /dev/null)
 	if [ "$EC" = "" ]; then
 		echo "0"
 	else
@@ -312,7 +312,7 @@ DetectEnterpriseConnect() {
 
 # Get the UPN from Enterprise Connect (code courtesy of Dennis Browning)
 GetUPNfromEnterpriseConnect() {
-	local ECUPN=$(${CMD_PREFIX} "/Applications/Enterprise Connect.app/Contents/SharedSupport/eccl" -a userPrincipalName | awk '/userPrincipalName:/{print $NF}' 2> /dev/null)
+	ECUPN=$(${CMD_PREFIX} "/Applications/Enterprise Connect.app/Contents/SharedSupport/eccl" -a userPrincipalName | awk '/userPrincipalName:/{print $NF}' 2> /dev/null)
 	if [ "$ECUPN" = "" ]; then
 		echo "0"
 	else

--- a/SignInHelper
+++ b/SignInHelper
@@ -344,8 +344,8 @@ done
 CMD_PREFIX=""
 ROOTLOGON=$(RunningAsRoot)
 if [ "$ROOTLOGON" == "1" ]; then
-	GetHomeFolder "$3"
 	CURRENTUSER=$(GetLoggedInUser)
+	GetHomeFolder "$CURRENTUSER"
 	if [ ! "$CURRENTUSER" == "0" ]; then
 		echo ">>INFO - Script is running in the root security context - running commands as user: $CURRENTUSER"
 		CMD_PREFIX="/usr/bin/sudo -u ${CURRENTUSER}"

--- a/SignInHelper
+++ b/SignInHelper
@@ -39,7 +39,7 @@ RunningAsRoot() {
 GetLoggedInUser() {
 	# The following line is courtesy of @scriptingosx - https://scriptingosx.com/2019/09/get-current-user-in-shell-scripts-on-macos/
 	local LOGGEDIN=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
-	if [ "$LOGGEDIN" == "" ]; then
+	if [ "$LOGGEDIN" = "" ]; then
 		echo "0"
 	else
 		echo "$LOGGEDIN"
@@ -49,7 +49,7 @@ GetLoggedInUser() {
 # HOME folder detection
 GetHomeFolder() {
 	HOME=$(dscl . read /Users/"$1" NFSHomeDirectory | cut -d ':' -f2 | cut -d ' ' -f2)
-	if [ "$HOME" == "" ]; then
+	if [ "$HOME" = "" ]; then
 		if [ -d "/Users/$1" ]; then
 			HOME="/Users/$1"
 		else
@@ -63,7 +63,7 @@ IsPrefManaged() {
 	local PREFKEY="$1"
 	local PREFDOMAIN="$2"
 	local MANAGED=$(/usr/bin/python -c "from Foundation import CFPreferencesAppValueIsForced; print CFPreferencesAppValueIsForced('${PREFKEY}', '${PREFDOMAIN}')")
-	if [ "$MANAGED" == "True" ]; then
+	if [ "$MANAGED" = "True" ]; then
 		echo "1"
 	else
 		echo "0"
@@ -73,7 +73,7 @@ IsPrefManaged() {
 # Detect Kerberos cache
 DetectKerbCache() {
 	local KERB=$(${CMD_PREFIX} /usr/bin/klist 2> /dev/null)
-	if [ "$KERB" == "" ]; then
+	if [ "$KERB" = "" ]; then
 		echo "0"
 	else
 		echo "1"
@@ -83,7 +83,7 @@ DetectKerbCache() {
 # Get the Kerberos principal from the cache
 GetPrincipal() {
 	local PRINCIPAL=$(${CMD_PREFIX} /usr/bin/klist | grep -o 'Principal: .*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
-	if [ "$PRINCIPAL" == "" ]; then
+	if [ "$PRINCIPAL" = "" ]; then
 		echo "0"
 	else
 		echo "$PRINCIPAL"
@@ -106,7 +106,7 @@ GetDomainName() {
 GetDefaultNamingContext() {
 	local DOMAIN="$1"
 	local DOMAINNC=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b '' -s base defaultNamingContext | grep -o 'defaultNamingContext:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
-	if [ "$DOMAINNC" == "" ]; then
+	if [ "$DOMAINNC" = "" ]; then
 		echo "0"
 	else
 		echo "$DOMAINNC"
@@ -119,7 +119,7 @@ GetUPN() {
 	local NAMESPACE="$2"
 	local ACCOUNT="$3"
 	local UPN=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT userPrincipalName | grep -o 'userPrincipalName:.*' | cut -d : -f2 | cut -d' ' -f2 2> /dev/null)
-	if [ "$UPN" == "" ]; then
+	if [ "$UPN" = "" ]; then
 		echo "0"
 	else
 		echo "$UPN"
@@ -132,7 +132,7 @@ GetDisplayName() {
 	local NAMESPACE="$2"
 	local ACCOUNT="$3"
 	local DISPLAYNAME=$(${CMD_PREFIX} /usr/bin/ldapsearch -H "ldap://$DOMAIN" -LLL -b "$NAMESPACE" -s sub samAccountName=$ACCOUNT displayName | grep -o 'displayName:.*' | cut -d : -f2 | cut -c 2- 2> /dev/null)
-	if [ "$DISPLAYNAME" == "" ]; then
+	if [ "$DISPLAYNAME" = "" ]; then
 		echo "0"
 	else
 		echo "$DISPLAYNAME"
@@ -146,7 +146,7 @@ GetInitials() {
 	local SECOND=$(echo ${DISPLAYNAME} | cut -d ' ' -f2 | cut -c 1)
 	local THIRD=$(echo ${DISPLAYNAME} | cut -d ' ' -f3 | cut -c 1)
 	local INITIALS=$(echo ${FIRST}${SECOND}${THIRD})
-	if [ "$INITIALS" == "" ]; then
+	if [ "$INITIALS" = "" ]; then
 		echo "0"
 	else
 		echo "$INITIALS"
@@ -166,11 +166,11 @@ SetPrefill() {
 SetPrefillOffice() {
 	local UPN="$1"
 	local KEYMANAGED=$(IsPrefManaged "OfficeActivationEmailAddress" "com.microsoft.office")
-	if [ "$KEYMANAGED" == "1" ]; then
+	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'OfficeActivationEmailAddress'"
 	else
 		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeActivationEmailAddress -string ${UPN}
-		if [ "$?" == "0" ]; then
+		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'OfficeActivationEmailAddress' to ${UPN}"
 		else
 			echo ">>ERROR - Did not set value for 'OfficeActivationEmailAddress'"
@@ -182,11 +182,11 @@ SetPrefillOffice() {
 # Set Office Automatic Office Sign In
 SetAutoSignIn() {
 	local KEYMANAGED=$(IsPrefManaged "OfficeAutoSignIn" "com.microsoft.office")
-	if [ "$KEYMANAGED" == "1" ]; then
+	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>WARNING - Cannot override managed preference 'OfficeAutoSignIn'"
 	else
 		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.office OfficeAutoSignIn -bool TRUE
-		if [ "$?" == "0" ]; then
+		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'OfficeAutoSignIn' to TRUE"
 		else
 			echo ">>ERROR - Did not set value for 'OfficeAutoSignIn'"
@@ -199,21 +199,21 @@ SetAutoSignIn() {
 SetOfficeUser() {
 	local USERNAME="$1"
 	local INITIALS="$2"
-	if [ "$USERNAME" == "" ]; then
+	if [ "$USERNAME" = "" ]; then
 		echo ">>WARNING - Cannot set Office user name"
 	else
 		${CMD_PREFIX} /usr/bin/defaults write ${HOME}/Library/Group\ Containers/UBF8T346G9.Office/MeContact.plist Name -string "${USERNAME}"
-		if [ "$?" == "0" ]; then
+		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set Office user name to '${USERNAME}'"
 		else
 			echo ">>WARNING - Did not set Office user name'"
 		fi
 	fi
-	if [ "$INITIALS" == "" ]; then
+	if [ "$INITIALS" = "" ]; then
 		echo ">>WARNING - Cannot set Office user initials"
 	else
 		${CMD_PREFIX} /usr/bin/defaults write ${HOME}/Library/Group\ Containers/UBF8T346G9.Office/MeContact.plist Initials -string "${INITIALS}"
-		if [ "$?" == "0" ]; then
+		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set Office user initials to '${INITIALS}'"
 		else
 			echo ">>WARNING - Did not set Office user initials'"
@@ -225,11 +225,11 @@ SetOfficeUser() {
 SetPrefillSkypeForBusiness() {
 	local UPN="$1"
 	local KEYMANAGED=$(IsPrefManaged "userName" "com.microsoft.SkypeForBusiness")
-	if [ "$KEYMANAGED" == "1" ]; then
+	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'userName'"
 	else
 		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness userName -string ${UPN}
-		if [ "$?" == "0" ]; then
+		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'userName' to ${UPN}"
 		else
 			echo ">>ERROR - Did not set value for 'userName'"
@@ -238,11 +238,11 @@ SetPrefillSkypeForBusiness() {
 	fi
 	local SIP="$1"
 	local KEYMANAGED=$(IsPrefManaged "sipAddress" "com.microsoft.SkypeForBusiness")
-	if [ "$KEYMANAGED" == "1" ]; then
+	if [ "$KEYMANAGED" = "1" ]; then
 		echo ">>ERROR - Cannot override managed preference 'sipAddress'"
 	else
 		${CMD_PREFIX} /usr/bin/defaults write com.microsoft.SkypeForBusiness sipAddress -string ${SIP}
-		if [ "$?" == "0" ]; then
+		if [ "$?" = "0" ]; then
 			echo ">>SUCCESS - Set 'sipAddress' to ${SIP}"
 		else
 			echo ">>ERROR - Did not set value for 'sipAddress'"
@@ -254,7 +254,7 @@ SetPrefillSkypeForBusiness() {
 # Detect Domain Join
 DetectDomainJoin() {
 	local DSCONFIGAD=$(${CMD_PREFIX} /usr/sbin/dsconfigad -show)
-	if [ "$DSCONFIGAD" == "" ]; then
+	if [ "$DSCONFIGAD" = "" ]; then
 		echo "0"
 	else
 		echo "1"
@@ -273,7 +273,7 @@ DetectJamf() {
 # Detect NoMAD presence
 DetectNoMAD() {
 	local NOMAD=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD 2> /dev/null)
-	if [ "$NOMAD" == "" ]; then
+	if [ "$NOMAD" = "" ]; then
 		echo "0"
 	else
 		echo "1"
@@ -283,7 +283,7 @@ DetectNoMAD() {
 # Get the UPN from NoMAD's preference cache
 GetUPNfromNoMAD() {
 	local NMUPN=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD UserUPN 2> /dev/null)
-	if [ "$NMUPN" == "" ]; then
+	if [ "$NMUPN" = "" ]; then
 		echo "0"
 	else
 		echo "$NMUPN"
@@ -293,7 +293,7 @@ GetUPNfromNoMAD() {
 # Get the DisplayName from NoMAD's preference cache
 GetDisplayNamefromNoMAD() {
 	local NMDISPLAYNAME=$(${CMD_PREFIX} /usr/bin/defaults read com.trusourcelabs.NoMAD DisplayName 2> /dev/null)
-	if [ "$NMDISPLAYNAME" == "" ]; then
+	if [ "$NMDISPLAYNAME" = "" ]; then
 		echo "0"
 	else
 		echo "$NMDISPLAYNAME"
@@ -303,7 +303,7 @@ GetDisplayNamefromNoMAD() {
 # Detect Enterprise Connect presence
 DetectEnterpriseConnect() {
 	local EC=$(${CMD_PREFIX} /usr/bin/defaults read com.apple.Enterprise-Connect 2> /dev/null)
-	if [ "$EC" == "" ]; then
+	if [ "$EC" = "" ]; then
 		echo "0"
 	else
 		echo "1"
@@ -313,7 +313,7 @@ DetectEnterpriseConnect() {
 # Get the UPN from Enterprise Connect (code courtesy of Dennis Browning)
 GetUPNfromEnterpriseConnect() {
 	local ECUPN=$(${CMD_PREFIX} "/Applications/Enterprise Connect.app/Contents/SharedSupport/eccl" -a userPrincipalName | awk '/userPrincipalName:/{print $NF}' 2> /dev/null)
-	if [ "$ECUPN" == "" ]; then
+	if [ "$ECUPN" = "" ]; then
 		echo "0"
 	else
 		echo "$ECUPN"
@@ -343,10 +343,10 @@ done
 # NOTE: CMD_PREFIX is intentionally implemented as a global variable
 CMD_PREFIX=""
 ROOTLOGON=$(RunningAsRoot)
-if [ "$ROOTLOGON" == "1" ]; then
+if [ "$ROOTLOGON" = "1" ]; then
 	CURRENTUSER=$(GetLoggedInUser)
 	GetHomeFolder "$CURRENTUSER"
-	if [ ! "$CURRENTUSER" == "0" ]; then
+	if [ ! "$CURRENTUSER" = "0" ]; then
 		echo ">>INFO - Script is running in the root security context - running commands as user: $CURRENTUSER"
 		CMD_PREFIX="/usr/bin/sudo -u ${CURRENTUSER}"
 	else
@@ -357,40 +357,40 @@ fi
 
 # Detect Active Directory connection style
 DJ=$(DetectDomainJoin)
-if [ "$DJ" == "1" ]; then
+if [ "$DJ" = "1" ]; then
 	echo ">>INFO - Detected that this machine is domain joined"
 fi
 NM=$(DetectNoMAD)
-if [ "$NM" == "1" ]; then
+if [ "$NM" = "1" ]; then
 	echo ">>INFO - Detected that this machine is running NoMAD"
 fi
 EC=$(DetectEnterpriseConnect)
-if [ "$EC" == "1" ]; then
+if [ "$EC" = "1" ]; then
 	echo ">>INFO - Detected that this machine is running Enterprise Connect"
 fi
 
 # Find out if a Kerberos principal and ticket is present
 UPN="0"
 KERBCACHE=$(DetectKerbCache)
-if [ "$KERBCACHE" == "1" ]; then
+if [ "$KERBCACHE" = "1" ]; then
 	echo ">>INFO - Detected Kerberos cache"
 	PRINCIPAL=$(GetPrincipal)
-	if [ ! "$PRINCIPAL" == "0" ]; then
+	if [ ! "$PRINCIPAL" = "0" ]; then
 		echo ">>INFO - Detected Kerberos principal: $PRINCIPAL"
 		# Get the account and domain name
 		ACCOUNT=$(GetAccountName "$PRINCIPAL")
 		DOMAIN=$(GetDomainName "$PRINCIPAL")
 		# Find the default naming context for Active Directory
 		NAMESPACE=$(GetDefaultNamingContext "$DOMAIN")
-		if [ ! "$NAMESPACE" == "0" ]; then
+		if [ ! "$NAMESPACE" = "0" ]; then
 			echo ">>INFO - Detected naming context: $NAMESPACE"
 			# Now to get the UPN
 			UPN=$(GetUPN "$DOMAIN" "$NAMESPACE" "$ACCOUNT")
-			if [ ! "$UPN" == "0" ]; then
+			if [ ! "$UPN" = "0" ]; then
 				echo ">>INFO - Found UPN: $UPN"
 				SetPrefill "$UPN"
 				DISPLAYNAME=$(GetDisplayName "$DOMAIN" "$NAMESPACE" "$ACCOUNT")
-				if [ ! "$DISPLAYNAME" == "0" ]; then
+				if [ ! "$DISPLAYNAME" = "0" ]; then
 					echo ">>INFO - Found DisplayName: $DISPLAYNAME"
 					INITIALS=$(GetInitials "$DISPLAYNAME")
 					SetOfficeUser "$DISPLAYNAME" "$INITIALS"
@@ -410,13 +410,13 @@ else
 fi
 
 # If we haven't got a UPN yet, see if we can get it from NoMAD's cache
-if [ "$UPN" == "0" ] && [ "$NM" == "1" ]; then
+if [ "$UPN" = "0" ] && [ "$NM" = "1" ]; then
 	UPN=$(GetUPNfromNoMAD)
-	if [ ! "$UPN" == "0" ]; then
+	if [ ! "$UPN" = "0" ]; then
 		echo ">>INFO - Found UPN from NoMAD: $UPN"
 		SetPrefill "$UPN"
 		DISPLAYNAME=$(GetDisplayNamefromNoMAD)
-			if [ ! "$DISPLAYNAME" == "0" ]; then
+			if [ ! "$DISPLAYNAME" = "0" ]; then
 				echo ">>INFO - Found DisplayName from NoMAD: $DISPLAYNAME"
 				INITIALS=$(GetInitials "$DISPLAYNAME")
 				SetOfficeUser "$DISPLAYNAME" "$INITIALS"
@@ -428,9 +428,9 @@ if [ "$UPN" == "0" ] && [ "$NM" == "1" ]; then
 fi
 
 # If we still haven't got a UPN, see if we can get it from Enterprise Connect (code courtesy of Dennis Browning)
-if [ "$UPN" == "0" ] && [ "$EC" == "1" ]; then
+if [ "$UPN" = "0" ] && [ "$EC" = "1" ]; then
 	UPN=$(GetUPNfromEnterpriseConnect)
-	if [ ! "$UPN" == "0" ]; then
+	if [ ! "$UPN" = "0" ]; then
 		echo ">>INFO - Found UPN from Enterprise Connect: $UPN"
 		SetPrefill "$UPN"
 		exit 0
@@ -440,7 +440,7 @@ if [ "$UPN" == "0" ] && [ "$EC" == "1" ]; then
 fi
 
 # If we still haven't got a UPN yet, show an error
-if [ "$UPN" == "0" ]; then
+if [ "$UPN" = "0" ]; then
 	echo ">>ERROR - Could not detect UPN"
 	exit 1
 fi

--- a/SignInHelper
+++ b/SignInHelper
@@ -37,8 +37,8 @@ function RunningAsRoot {
 
 # Returns the name of the logged-in user, which is useful if the script is running in the root context
 function GetLoggedInUser {
-	# The following line is courtesy of @macmule - https://macmule.com/2014/11/19/how-to-get-the-currently-logged-in-user-in-a-more-apple-approved-way/
-	local LOGGEDIN=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+	# The following line is courtesy of @scriptingosx - https://scriptingosx.com/2019/09/get-current-user-in-shell-scripts-on-macos/
+	local LOGGEDIN=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 	if [ "$LOGGEDIN" == "" ]; then
 		echo "0"
 	else


### PR DESCRIPTION
When running this script in environments where `$3` is undefined, the script would appear to run successfully but actually write to an incorrect path: __~/Library/Preferences/dsRecTypeStandard/Library/Group Containers/UBF8T346G9.Office/MeContact.plist__

This can be solved by using the `$CURRENTUSER` variable (which the script obtains already for other uses) instead of `$3` for the `GetHomeFolder()` function.

This pull request makes that change, in addition to various [shellcheck](https://github.com/koalaman/shellcheck) suggestions and alignment with /bin/sh syntax. I took the liberty of incrementing the version to 1.3.0, but feel free to edit that as you see fit.